### PR TITLE
Add exchange support for RabbitMQ

### DIFF
--- a/.env.shared.example
+++ b/.env.shared.example
@@ -1,0 +1,2 @@
+# Shared environment variables
+RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672

--- a/apps/analyzer/rabbit_consumer.py
+++ b/apps/analyzer/rabbit_consumer.py
@@ -7,13 +7,15 @@ from reports.markovitz.pipeline import process_markovitz_report
 from reports.gbm.pipeline import process_gbm_report
 from sqlalchemy import text
 from database import engine
+import numpy as np
 
 async def handle_report_created(payload):
     print(f"📥 Получено событие report.created: {payload}", flush=True)
 
-    report_id = payload["id"]
-    report_type = payload["reportType"]
-    input_params = payload.get("inputParams", {})
+    data = payload.get("data", payload)  # поддержка как обёрнутого, так и голого payload
+    report_id = data["id"]
+    report_type = data["reportType"]
+    input_params = data.get("inputParams", {})
     publisher = RabbitPublisher()
 
     try:
@@ -21,16 +23,11 @@ async def handle_report_created(payload):
             result = process_markovitz_report(
                 report_id=report_id,
                 additional_tickers=input_params.get("additionalTickers", []),
-                date_range=input_params.get("date_range")
-                or input_params.get("dateRange", "3y"),
-                risk_free_rate=input_params.get("risk_free_rate")
-                or input_params.get("riskFreeRate"),
-                num_portfolios=input_params.get("num_portfolios")
-                or input_params.get("numPortfolios"),
-                cov_method=input_params.get("cov_method")
-                or input_params.get("covMethod"),
-                target_currency=input_params.get("target_currency")
-                or input_params.get("currency", "usd"),
+                date_range=input_params.get("date_range") or input_params.get("dateRange", "3y"),
+                risk_free_rate=input_params.get("risk_free_rate") or input_params.get("riskFreeRate"),
+                num_portfolios=input_params.get("num_portfolios") or input_params.get("numPortfolios"),
+                cov_method=input_params.get("cov_method") or input_params.get("covMethod"),
+                target_currency=input_params.get("target_currency") or input_params.get("currency", "usd"),
             )
 
         elif report_type == "future_returns_forecast_gbm":
@@ -38,15 +35,14 @@ async def handle_report_created(payload):
                 report_id=report_id,
                 selected_percentiles=input_params.get("selectedPercentiles", [10, 50, 90]),
                 forecast_horizons=input_params.get("forecastHorizons", [30, 60, 90, 180, 365]),
-                date_range=input_params.get("date_range")
-                or input_params.get("dateRange", "3y"),
-                target_currency=input_params.get("target_currency")
-                or input_params.get("currency", "usd"),
+                date_range=input_params.get("date_range") or input_params.get("dateRange", "3y"),
+                target_currency=input_params.get("target_currency") or input_params.get("currency", "usd"),
             )
 
         else:
             raise ValueError(f"Неподдерживаемый тип отчёта: {report_type}")
 
+        # Обновляем статус в БД
         with engine.connect() as conn:
             conn.execute(text("""
                 UPDATE portfolio_reports
@@ -58,44 +54,50 @@ async def handle_report_created(payload):
             })
             conn.commit()
 
+        def clean_floats(obj):
+            if isinstance(obj, dict):
+                return {k: clean_floats(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [clean_floats(v) for v in obj]
+            elif isinstance(obj, np.float64):
+                return float(obj)
+            return obj
+        result_clean = clean_floats(result)
+
+        # Отправляем событие об успешном обновлении
         await publisher.send_event("report.updated", {
             "id": report_id,
             "status": "ready",
-            "result": result,
+            "data": result_clean,
         })
 
         print(f"✅ Отчёт {report_id} успешно рассчитан и обновлён", flush=True)
 
     except Exception as e:
         error_message = str(e)
-        print(
-            f"❌ Ошибка при расчёте отчёта {report_id}: {error_message}",
-            flush=True,
-        )
+        print(f"❌ Ошибка при расчёте отчёта {report_id}: {error_message}", flush=True)
 
         try:
             with engine.connect() as conn:
-                conn.execute(
-                    text(
-                        """
-                UPDATE portfolio_reports
-                SET status = 'error', "errorMessage" = :msg
-                WHERE id = :report_id
-            """
-                    ),
-                    {"msg": error_message, "report_id": report_id},
-                )
+                conn.execute(text("""
+                    UPDATE portfolio_reports
+                    SET status = 'error', "errorMessage" = :msg
+                    WHERE id = :report_id
+                """), {
+                    "msg": error_message,
+                    "report_id": report_id
+                })
                 conn.commit()
         except Exception as db_error:
-            print(
-                f"❌ Failed to update report {report_id} status: {db_error}",
-                flush=True,
-            )
+            print(f"❌ Failed to update report {report_id} status: {db_error}", flush=True)
 
-        await publisher.send_event(
-            "report.updated",
-            {"id": report_id, "status": "error", "errorMessage": error_message},
-        )
+        # Отправляем событие об ошибке
+        await publisher.send_event("report.updated", {
+            "id": report_id,
+            "status": "error",
+            "errorMessage": error_message,
+        })
+
 
 
 async def consume():
@@ -110,12 +112,13 @@ async def consume():
 
     async with queue.iterator() as queue_iter:
         async for message in queue_iter:
-            try:
-                payload = json.loads(message.body.decode())
-                print(f'message {message}', flush=True)
-                if message.routing_key == "report.created":
-                    await handle_report_created(payload)
-                await message.ack()
-            except Exception as e:
-                print(f"❌ Error processing message: {e}", flush=True)
-                await message.nack(requeue=True)
+            async with message.process():  # ✅ автоматически ack + requeue on error
+                try:
+                    payload = json.loads(message.body.decode())
+
+                    # ⚠️ payload — это уже тело, а не {'data': payload}
+                    if message.routing_key == "report.created":
+                        await handle_report_created(payload)
+
+                except Exception as e:
+                    print(f"❌ Error processing message: {e}", flush=True)

--- a/apps/analyzer/rabbitmq.py
+++ b/apps/analyzer/rabbitmq.py
@@ -16,7 +16,9 @@ class RabbitPublisher:
             await self.connect()
 
         channel = await self.connection.channel()
-        await channel.default_exchange.publish(
-            aio_pika.Message(body=json.dumps(payload).encode()),
-            routing_key=routing_key,
+        exchange = await channel.declare_exchange(
+            "reports_exchange", aio_pika.ExchangeType.DIRECT, durable=True
+        )
+        await exchange.publish(
+            aio_pika.Message(body=json.dumps(payload).encode()), routing_key=routing_key
         )

--- a/apps/analyzer/rabbitmq.py
+++ b/apps/analyzer/rabbitmq.py
@@ -2,27 +2,48 @@ import aio_pika
 import asyncio
 import json
 import os
-from typing import Any
+from typing import Any, Optional
+
 
 class RabbitPublisher:
-    def __init__(self, url: str | None = None):
+    def __init__(self, url: Optional[str] = None):
         self.url = url or os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq/")
-        self.connection: aio_pika.RobustConnection | None = None
+        self.connection: Optional[aio_pika.RobustConnection] = None
+        self.channel: Optional[aio_pika.Channel] = None
+        self.exchange: Optional[aio_pika.Exchange] = None
 
     async def connect(self):
-        self.connection = await aio_pika.connect_robust(self.url)
+        if not self.connection:
+            self.connection = await aio_pika.connect_robust(self.url)
+
+        if not self.channel:
+            self.channel = await self.connection.channel()
+
+        if not self.exchange:
+            self.exchange = await self.channel.declare_exchange(
+                "reports_exchange", aio_pika.ExchangeType.DIRECT, durable=True
+            )
 
     async def send_event(self, routing_key: str, payload: Any):
-        if not self.connection:
-            await self.connect()
+        print('send_event ---!!!', flush=True)
+        await self.connect()
 
-        channel = await self.connection.channel()
-        exchange = await channel.declare_exchange(
-            "reports_exchange", aio_pika.ExchangeType.DIRECT, durable=True
-        )
+        message = {
+            "pattern": routing_key,
+            "data": payload,
+        }
+
+        body = json.dumps(message).encode()
+
         try:
-            await exchange.publish(
-                aio_pika.Message(body=json.dumps(payload).encode()), routing_key=routing_key
+            await self.exchange.publish(
+                aio_pika.Message(
+                    body=body,
+                    content_type="application/json"
+                ),
+                routing_key=routing_key
             )
+            print(f"📤 Событие отправлено: {routing_key} → {payload}", flush=True)
+
         except Exception as e:
-            print(f"❌ Failed to publish event: {e}", flush=True)
+            print(f"❌ Failed to publish event '{routing_key}': {e}", flush=True)

--- a/apps/analyzer/rabbitmq.py
+++ b/apps/analyzer/rabbitmq.py
@@ -1,11 +1,12 @@
 import aio_pika
 import asyncio
 import json
+import os
 from typing import Any
 
 class RabbitPublisher:
-    def __init__(self, url: str = "amqp://guest:guest@rabbitmq/"):
-        self.url = url
+    def __init__(self, url: str | None = None):
+        self.url = url or os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq/")
         self.connection: aio_pika.RobustConnection | None = None
 
     async def connect(self):
@@ -19,6 +20,9 @@ class RabbitPublisher:
         exchange = await channel.declare_exchange(
             "reports_exchange", aio_pika.ExchangeType.DIRECT, durable=True
         )
-        await exchange.publish(
-            aio_pika.Message(body=json.dumps(payload).encode()), routing_key=routing_key
-        )
+        try:
+            await exchange.publish(
+                aio_pika.Message(body=json.dumps(payload).encode()), routing_key=routing_key
+            )
+        except Exception as e:
+            print(f"❌ Failed to publish event: {e}", flush=True)

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -29,9 +29,10 @@ async function bootstrap() {
 	await syncPortfolioVersions(app);
 	await syncPortfolioReportsVersions(app);
 
-	app.connectMicroservice(config.connectMicroService.portfolioQueue);
+        app.connectMicroservice(config.connectMicroService.portfolioQueue);
+        await app.startAllMicroservices();
 
-	await app.listen(4000, '0.0.0.0');
+        await app.listen(4000, '0.0.0.0');
 }
 
 void bootstrap();

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -22,17 +22,17 @@ async function bootstrap() {
 		next();
 	});
 
-	// app.use(config.rateLimit);
+	app.use(config.rateLimit);
 
-	// app.useGlobalGuards(new GqlTokenThrottleGuard());
+	app.useGlobalGuards(new GqlTokenThrottleGuard());
 
 	await syncPortfolioVersions(app);
 	await syncPortfolioReportsVersions(app);
 
-        app.connectMicroservice(config.connectMicroService.portfolioQueue);
-        await app.startAllMicroservices();
+    app.connectMicroservice(config.connectMicroService.portfolioQueue);
+    await app.startAllMicroservices();
 
-        await app.listen(4000, '0.0.0.0');
+    await app.listen(4000, '0.0.0.0');
 }
 
 void bootstrap();

--- a/apps/backend/src/modules/portfolio-report/application/portfolio-report.service.ts
+++ b/apps/backend/src/modules/portfolio-report/application/portfolio-report.service.ts
@@ -83,33 +83,15 @@ export class PortfolioReportService {
 	async createMarkovitzReport(portfolioId: number, input: MarkovitzReportInput): Promise<PortfolioReport> {
 		const savedReport = await this.createDefaultReport(portfolioId, 'markowitz', input);
 
-		// Переводим на event-driven архитектуру
-		this.analyzeMarkovitzPortfolio(savedReport.id, input).catch(async (error) => {
-			console.error('Ошибка при анализе портфеля:', error);
-			await this.reportRepository.update(savedReport.id, {
-				status: 'error',
-				errorMessage: 'Ошибка при анализе портфеля',
-			});
-		});
-
-		return savedReport;
-	}
+                return savedReport;
+        }
 
 	// Создать отчет с изначальным статусом "calculating"
 	async createFutureReturnForecastGBMReport(portfolioId: number, input: FutureReturnForecastInput): Promise<PortfolioReport> {
 		const savedReport = await this.createDefaultReport(portfolioId, 'future_returns_forecast_gbm', input);
 
-		// Переводим на event-driven архитектуру
-		this.analyzeFutureReturnsForecastGBM(savedReport.id, input).catch(async (error) => {
-			console.error('Ошибка при анализе портфеля:', error);
-			await this.reportRepository.update(savedReport.id, {
-				status: 'error',
-				errorMessage: 'Ошибка при анализе портфеля',
-			});
-		});
-
-		return savedReport;
-	}
+                return savedReport;
+        }
 
 	// Обновить отчет (данные + статус)
 	async updateReport(reportId: string, data: any, status: 'ready' | 'error', errorMessage?: string): Promise<PortfolioReport> {

--- a/apps/backend/src/modules/portfolio-report/application/portfolio-report.service.ts
+++ b/apps/backend/src/modules/portfolio-report/application/portfolio-report.service.ts
@@ -60,13 +60,13 @@ export class PortfolioReportService {
 
 		if (!savedReport) throw new Error(`Ошибка при создании портфеля (reportType: "markowitz"`);
 
-                console.log('createDefaultReport PortfolioReportEvents.created');
-                /** Внешнее событие */
-                await this.rmqPublisher.emit(PortfolioReportEvents.created, {
-                        ...savedReport,
-                        portfolio: portfolioId,
+        /** Внешнее событие */
+        await this.rmqPublisher.emit(PortfolioReportEvents.created, {
+            ...savedReport,
+            portfolio: portfolioId,
 			inputParams,
 		});
+
 		return savedReport;
 	}
 
@@ -74,15 +74,15 @@ export class PortfolioReportService {
 	async createMarkovitzReport(portfolioId: number, input: MarkovitzReportInput): Promise<PortfolioReport> {
 		const savedReport = await this.createDefaultReport(portfolioId, 'markowitz', input);
 
-                return savedReport;
-        }
+        return savedReport;
+    }
 
 	// Создать отчет с изначальным статусом "calculating"
 	async createFutureReturnForecastGBMReport(portfolioId: number, input: FutureReturnForecastInput): Promise<PortfolioReport> {
 		const savedReport = await this.createDefaultReport(portfolioId, 'future_returns_forecast_gbm', input);
 
-                return savedReport;
-        }
+        return savedReport;
+    }
 
 	// Обновить отчет (данные + статус)
 	async updateReport(reportId: string, data: any, status: 'ready' | 'error', errorMessage?: string): Promise<PortfolioReport> {
@@ -106,21 +106,22 @@ export class PortfolioReportService {
 		return this.reportRepository.findOne({where: {id: reportId}});
 	}
 
-        async deleteReport(reportId: string): Promise<boolean> {
-                const report = await this.reportRepository.findOne({
-                        where: {id: reportId},
-                        loadRelationIds: {relations: ['portfolio']},
-                });
-                if (!report) return false;
+    async deleteReport(reportId: string): Promise<boolean> {
+        const report = await this.reportRepository.findOne({
+            where: {id: reportId},
+            loadRelationIds: {relations: ['portfolio']},
+        });
 
-                report.deleted = true;
-                report.version = this.portfolioReportStore.maxVersion() + 1;
+        if (!report) return false;
 
-                await this.reportRepository.save(report);
-                await this.rmqPublisher.emit(PortfolioReportEvents.updated, report);
+        report.deleted = true;
+        report.version = this.portfolioReportStore.maxVersion() + 1;
 
-                return true;
-        }
+        await this.reportRepository.save(report);
+        await this.rmqPublisher.emit(PortfolioReportEvents.updated, report);
+
+        return true;
+    }
 
 	async getDistributedPortfolioAssets(
 		capital: number,

--- a/apps/backend/src/modules/portfolio-report/domain/portfolio-report.events.ts
+++ b/apps/backend/src/modules/portfolio-report/domain/portfolio-report.events.ts
@@ -1,4 +1,5 @@
 export enum PortfolioReportEvents {
-	created = 'report.created',
-	updated = 'report.updated',
+        created = 'report.created',
+        updated = 'report.updated',
+        deleted = 'report.deleted',
 }

--- a/apps/backend/src/modules/portfolio-report/infrastructure/portfolio-report-events.controller.ts
+++ b/apps/backend/src/modules/portfolio-report/infrastructure/portfolio-report-events.controller.ts
@@ -16,21 +16,21 @@ export class PortfolioReportEventsController {
 		context.getChannelRef().ack(context.getMessage());
 	}
 
-        @EventPattern(PortfolioReportEvents.updated)
-        handleReportUpdated(@Payload() payload: PortfolioReport, @Ctx() context: RmqContext) {
-                console.log('---handleReportUpdated / payload---');
-                console.dir(payload);
+    @EventPattern(PortfolioReportEvents.updated)
+    handleReportUpdated(@Payload() payload: PortfolioReport, @Ctx() context: RmqContext) {
+        console.log('---handleReportUpdated / payload---');
+        console.dir(payload);
 
-                this.syncService.handlePortfolioUpdated(payload);
-                context.getChannelRef().ack(context.getMessage());
-        }
+        this.syncService.handlePortfolioUpdated(payload);
+        context.getChannelRef().ack(context.getMessage());
+    }
 
-       @EventPattern(PortfolioReportEvents.deleted)
-       handleReportDeleted(@Payload() payload: PortfolioReport, @Ctx() context: RmqContext) {
-               console.log('---handleReportDeleted / payload---');
-               console.dir(payload);
+   @EventPattern(PortfolioReportEvents.deleted)
+   handleReportDeleted(@Payload() payload: PortfolioReport, @Ctx() context: RmqContext) {
+       console.log('---handleReportDeleted / payload---');
+       console.dir(payload);
 
-               this.syncService.handlePortfolioDeleted(payload);
-               context.getChannelRef().ack(context.getMessage());
-       }
+       this.syncService.handlePortfolioDeleted(payload);
+       context.getChannelRef().ack(context.getMessage());
+   }
 }

--- a/apps/backend/src/modules/portfolio-report/infrastructure/portfolio-report-events.controller.ts
+++ b/apps/backend/src/modules/portfolio-report/infrastructure/portfolio-report-events.controller.ts
@@ -16,12 +16,21 @@ export class PortfolioReportEventsController {
 		context.getChannelRef().ack(context.getMessage());
 	}
 
-	@EventPattern(PortfolioReportEvents.updated)
-	handleReportUpdated(@Payload() payload: PortfolioReport, @Ctx() context: RmqContext) {
-		console.log('---handleReportUpdated / payload---');
-		console.dir(payload);
+        @EventPattern(PortfolioReportEvents.updated)
+        handleReportUpdated(@Payload() payload: PortfolioReport, @Ctx() context: RmqContext) {
+                console.log('---handleReportUpdated / payload---');
+                console.dir(payload);
 
-		this.syncService.handlePortfolioUpdated(payload);
-		context.getChannelRef().ack(context.getMessage());
-	}
+                this.syncService.handlePortfolioUpdated(payload);
+                context.getChannelRef().ack(context.getMessage());
+        }
+
+       @EventPattern(PortfolioReportEvents.deleted)
+       handleReportDeleted(@Payload() payload: PortfolioReport, @Ctx() context: RmqContext) {
+               console.log('---handleReportDeleted / payload---');
+               console.dir(payload);
+
+               this.syncService.handlePortfolioDeleted(payload);
+               context.getChannelRef().ack(context.getMessage());
+       }
 }

--- a/apps/backend/src/modules/portfolio-report/infrastructure/porttolio-report.memory-sync.service.ts
+++ b/apps/backend/src/modules/portfolio-report/infrastructure/porttolio-report.memory-sync.service.ts
@@ -13,13 +13,13 @@ export class PortfolioReportMemorySyncService {
 		this.portfolioStore.addItem(portfolio);
 	}
 
-        @OnEvent(PortfolioReportEvents.updated)
-        handlePortfolioUpdated(portfolio: PortfolioReport) {
-                this.portfolioStore.updateItem(portfolio);
-        }
+    @OnEvent(PortfolioReportEvents.updated)
+    handlePortfolioUpdated(portfolio: PortfolioReport) {
+        this.portfolioStore.updateItem(portfolio);
+    }
 
-       @OnEvent(PortfolioReportEvents.deleted)
-       handlePortfolioDeleted(portfolio: PortfolioReport) {
-               this.portfolioStore.updateItem(portfolio);
-       }
+   @OnEvent(PortfolioReportEvents.deleted)
+   handlePortfolioDeleted(portfolio: PortfolioReport) {
+       this.portfolioStore.updateItem(portfolio);
+   }
 }

--- a/apps/backend/src/modules/portfolio-report/infrastructure/porttolio-report.memory-sync.service.ts
+++ b/apps/backend/src/modules/portfolio-report/infrastructure/porttolio-report.memory-sync.service.ts
@@ -13,8 +13,13 @@ export class PortfolioReportMemorySyncService {
 		this.portfolioStore.addItem(portfolio);
 	}
 
-	@OnEvent(PortfolioReportEvents.updated)
-	handlePortfolioUpdated(portfolio: PortfolioReport) {
-		this.portfolioStore.updateItem(portfolio);
-	}
+        @OnEvent(PortfolioReportEvents.updated)
+        handlePortfolioUpdated(portfolio: PortfolioReport) {
+                this.portfolioStore.updateItem(portfolio);
+        }
+
+       @OnEvent(PortfolioReportEvents.deleted)
+       handlePortfolioDeleted(portfolio: PortfolioReport) {
+               this.portfolioStore.updateItem(portfolio);
+       }
 }

--- a/apps/backend/src/modules/portfolio-report/interface/portfolio-report.resolver.ts
+++ b/apps/backend/src/modules/portfolio-report/interface/portfolio-report.resolver.ts
@@ -19,7 +19,7 @@ export class PortfolioReportResolver {
 		@AuthUser() _user: User,
 		@Args('portfolioId', {type: () => Int}) portfolioId: number,
 		@Args('input') input: MarkovitzReportInput,
-	): Promise<PortfolioReport> {
+	): Promise<PortfolioReport | null> {
 		return this.portfolioReportService.createMarkovitzReport(portfolioId, input);
 	}
 
@@ -29,7 +29,7 @@ export class PortfolioReportResolver {
 		@AuthUser() _user: User,
 		@Args('portfolioId', {type: () => Int}) portfolioId: number,
 		@Args('input') input: FutureReturnForecastInput,
-	): Promise<PortfolioReport> {
+	): Promise<PortfolioReport | null> {
 		return this.portfolioReportService.createFutureReturnForecastGBMReport(
 			portfolioId,
 			input,

--- a/apps/backend/src/shared/cache/memory-cache.store.ts
+++ b/apps/backend/src/shared/cache/memory-cache.store.ts
@@ -55,6 +55,13 @@ export class MemoryCacheStore<T extends { id: number | string; version: number; 
 	/** Безопасная функция получения store по сущности */
 	private getStoreByItem(item: T): StoreEntry<T> {
 		const key = this._aggregateFn(item);
+		if (key === undefined) {
+			let foundStore: StoreEntry<T> | null;
+			console.log('this._itemsByAggregateKey.values()', this._itemsByAggregateKey.values());
+			foundStore = [...this._itemsByAggregateKey.values()].find((store) => store.byId.has(item.id)) ?? null;;
+
+			if (foundStore) return foundStore;
+		}
 		return this.getOrCreateStore(key);
 	}
 
@@ -89,8 +96,10 @@ export class MemoryCacheStore<T extends { id: number | string; version: number; 
 	updateItem(newItem: T) {
 		const store = this.getStoreByItem(newItem);
 
+		console.log('store', store);
 		// Получаем элемент по id
 		const item = store.byId.get(newItem.id);
+		console.log('item', this._itemsByAggregateKey, item, newItem, newItem.id);
 		// Если мы не нашли этот элемент, то выходим
 		if (!item || !store.versionSortedIndex.has(item.version) || newItem.version <= item.version) {
 			throw new Error(

--- a/apps/backend/src/shared/guards/gql-token-throttle.guard.ts
+++ b/apps/backend/src/shared/guards/gql-token-throttle.guard.ts
@@ -17,7 +17,7 @@ export class TooManyRequestsException extends HttpException {
 export class GqlTokenThrottleGuard implements CanActivate {
 	private readonly requestCounts = new Map<string, number>();
 	private readonly windowMs = 60 * 1000;
-	private readonly limit = 60;
+	private readonly limit = 120;
 
 	canActivate(context: ExecutionContext): boolean {
 		const ctx = GqlExecutionContext.create(context);

--- a/apps/backend/src/shared/rmq/rmq-publisher.service.ts
+++ b/apps/backend/src/shared/rmq/rmq-publisher.service.ts
@@ -1,14 +1,17 @@
-import {Injectable} from '@nestjs/common';
+import {Injectable, Logger} from '@nestjs/common';
 import {connect, ChannelWrapper} from 'amqp-connection-manager';
-import {RmqExchanges} from './rmq.config';
+import {RmqExchanges, RmqQueues} from './rmq.config';
 import {ConfirmChannel} from 'amqplib';
 
 @Injectable()
 export class RmqPublisherService {
+       private readonly logger = new Logger(RmqPublisherService.name);
        private channel: ChannelWrapper;
 
        constructor() {
-               const connection = connect(['amqp://guest:guest@rabbitmq:5672']);
+               const connection = connect([
+                       process.env.RABBITMQ_URL || 'amqp://guest:guest@rabbitmq:5672',
+               ]);
                this.channel = connection.createChannel({
                        json: true,
                        setup: async (channel: ConfirmChannel) => {
@@ -17,15 +20,31 @@ export class RmqPublisherService {
                                        'direct',
                                        {durable: true},
                                );
+                               await channel.assertQueue(RmqQueues.portfolio.queue, {durable: true});
+                               await channel.bindQueue(
+                                       RmqQueues.portfolio.queue,
+                                       RmqExchanges.reports,
+                                       'report.created',
+                               );
+                               await channel.assertQueue(RmqQueues.analyzer.queue, {durable: true});
+                               await channel.bindQueue(
+                                       RmqQueues.analyzer.queue,
+                                       RmqExchanges.reports,
+                                       'report.created',
+                               );
                        },
                });
        }
 
        async emit(routingKey: string, payload: any) {
-               await this.channel.publish(
-                       RmqExchanges.reports,
-                       routingKey,
-                       payload,
-               );
+               try {
+                       await this.channel.publish(
+                               RmqExchanges.reports,
+                               routingKey,
+                               payload,
+                       );
+               } catch (err) {
+                       this.logger.error('Failed to publish message', err as Error);
+               }
        }
 }

--- a/apps/backend/src/shared/rmq/rmq-publisher.service.ts
+++ b/apps/backend/src/shared/rmq/rmq-publisher.service.ts
@@ -26,11 +26,32 @@ export class RmqPublisherService {
                                        RmqExchanges.reports,
                                        'report.created',
                                );
+                               await channel.bindQueue(
+                                       RmqQueues.portfolio.queue,
+                                       RmqExchanges.reports,
+                                       'report.updated',
+                               );
+                               await channel.bindQueue(
+                                       RmqQueues.portfolio.queue,
+                                       RmqExchanges.reports,
+                                       'report.deleted',
+                               );
+
                                await channel.assertQueue(RmqQueues.analyzer.queue, {durable: true});
                                await channel.bindQueue(
                                        RmqQueues.analyzer.queue,
                                        RmqExchanges.reports,
                                        'report.created',
+                               );
+                               await channel.bindQueue(
+                                       RmqQueues.analyzer.queue,
+                                       RmqExchanges.reports,
+                                       'report.updated',
+                               );
+                               await channel.bindQueue(
+                                       RmqQueues.analyzer.queue,
+                                       RmqExchanges.reports,
+                                       'report.deleted',
                                );
                        },
                });

--- a/apps/backend/src/shared/rmq/rmq-publisher.service.ts
+++ b/apps/backend/src/shared/rmq/rmq-publisher.service.ts
@@ -5,67 +5,70 @@ import {ConfirmChannel} from 'amqplib';
 
 @Injectable()
 export class RmqPublisherService {
-       private readonly logger = new Logger(RmqPublisherService.name);
-       private channel: ChannelWrapper;
+	private readonly logger = new Logger(RmqPublisherService.name);
+	private channel: ChannelWrapper;
 
-       constructor() {
-               const connection = connect([
-                       process.env.RABBITMQ_URL || 'amqp://guest:guest@rabbitmq:5672',
-               ]);
-               this.channel = connection.createChannel({
-                       json: true,
-                       setup: async (channel: ConfirmChannel) => {
-                               await channel.assertExchange(
-                                       RmqExchanges.reports,
-                                       'direct',
-                                       {durable: true},
-                               );
-                               await channel.assertQueue(RmqQueues.portfolio.queue, {durable: true});
-                               await channel.bindQueue(
-                                       RmqQueues.portfolio.queue,
-                                       RmqExchanges.reports,
-                                       'report.created',
-                               );
-                               await channel.bindQueue(
-                                       RmqQueues.portfolio.queue,
-                                       RmqExchanges.reports,
-                                       'report.updated',
-                               );
-                               await channel.bindQueue(
-                                       RmqQueues.portfolio.queue,
-                                       RmqExchanges.reports,
-                                       'report.deleted',
-                               );
+	constructor() {
+		const connection = connect([
+			process.env.RABBITMQ_URL || 'amqp://guest:guest@rabbitmq:5672',
+		]);
+		this.channel = connection.createChannel({
+			json: true,
+			setup: async (channel: ConfirmChannel) => {
+				await channel.assertExchange(
+					RmqExchanges.reports,
+					'direct',
+					{durable: true},
+				);
+				await channel.assertQueue(RmqQueues.portfolio.queue, {durable: true});
+				await channel.bindQueue(
+					RmqQueues.portfolio.queue,
+					RmqExchanges.reports,
+					'report.created',
+				);
+				await channel.bindQueue(
+					RmqQueues.portfolio.queue,
+					RmqExchanges.reports,
+					'report.updated',
+				);
+				await channel.bindQueue(
+					RmqQueues.portfolio.queue,
+					RmqExchanges.reports,
+					'report.deleted',
+				);
 
-                               await channel.assertQueue(RmqQueues.analyzer.queue, {durable: true});
-                               await channel.bindQueue(
-                                       RmqQueues.analyzer.queue,
-                                       RmqExchanges.reports,
-                                       'report.created',
-                               );
-                               await channel.bindQueue(
-                                       RmqQueues.analyzer.queue,
-                                       RmqExchanges.reports,
-                                       'report.updated',
-                               );
-                               await channel.bindQueue(
-                                       RmqQueues.analyzer.queue,
-                                       RmqExchanges.reports,
-                                       'report.deleted',
-                               );
-                       },
-               });
-       }
+				await channel.assertQueue(RmqQueues.analyzer.queue, {durable: true});
+				await channel.bindQueue(
+					RmqQueues.analyzer.queue,
+					RmqExchanges.reports,
+					'report.created',
+				);
+				await channel.bindQueue(
+					RmqQueues.analyzer.queue,
+					RmqExchanges.reports,
+					'report.updated',
+				);
+				await channel.bindQueue(
+					RmqQueues.analyzer.queue,
+					RmqExchanges.reports,
+					'report.deleted',
+				);
+			},
+		});
+	}
 
-       async emit(routingKey: string, payload: any) {
-               try {
-                       await this.channel.publish(
-                               RmqExchanges.reports,
-                               routingKey,
-                               payload,
-                       );
-               } catch (err) {
-                       this.logger.error('Failed to publish message', err as Error);
-               }
-       }
+	async emit(routingKey: string, payload: any) {
+		try {
+			await this.channel.publish(
+				RmqExchanges.reports,
+				routingKey,
+				{
+					pattern: routingKey,
+					data: payload,
+				},
+			);
+		} catch (err) {
+			this.logger.error('Failed to publish message', err as Error);
+		}
+	}
 }

--- a/apps/backend/src/shared/rmq/rmq.config.ts
+++ b/apps/backend/src/shared/rmq/rmq.config.ts
@@ -1,23 +1,32 @@
 import {RmqOptions} from '@nestjs/microservices';
 
 export const RmqQueues = {
-	portfolio: {
-		name: 'RABBITMQ_PORTFOLIO_CLIENT',
-		queue: 'portfolio_events_queue',
-	},
-	// можно добавить другие очереди позже:
-	// reports: {
-	//   name: 'RABBITMQ_REPORTS_CLIENT',
-	//   queue: 'report_events_queue',
-	// },
+       portfolio: {
+               name: 'RABBITMQ_PORTFOLIO_CLIENT',
+               queue: 'portfolio_events_queue',
+       },
+       // можно добавить другие очереди позже:
+       // reports: {
+       //   name: 'RABBITMQ_REPORTS_CLIENT',
+       //   queue: 'report_events_queue',
+       // },
+};
+
+export const RmqExchanges = {
+       reports: 'reports_exchange',
 };
 
 export function createRmqClientOptions(queueName: string): RmqOptions['options'] {
-	return {
-		urls: ['amqp://guest:guest@rabbitmq:5672'], // позже подключим dotenv
-		queue: queueName,
-		queueOptions: {
-			durable: true,
-		},
-	};
+       return {
+               urls: ['amqp://guest:guest@rabbitmq:5672'], // позже подключим dotenv
+               queue: queueName,
+               queueOptions: {
+                       durable: true,
+               },
+               exchange: RmqExchanges.reports,
+               exchangeType: 'direct',
+               exchangeOptions: {
+                       durable: true,
+               },
+       };
 }

--- a/apps/backend/src/shared/rmq/rmq.config.ts
+++ b/apps/backend/src/shared/rmq/rmq.config.ts
@@ -5,6 +5,9 @@ export const RmqQueues = {
                name: 'RABBITMQ_PORTFOLIO_CLIENT',
                queue: 'portfolio_events_queue',
        },
+       analyzer: {
+               queue: 'analyzer_events_queue',
+       },
        // можно добавить другие очереди позже:
        // reports: {
        //   name: 'RABBITMQ_REPORTS_CLIENT',
@@ -18,14 +21,9 @@ export const RmqExchanges = {
 
 export function createRmqClientOptions(queueName: string): RmqOptions['options'] {
        return {
-               urls: ['amqp://guest:guest@rabbitmq:5672'], // позже подключим dotenv
+               urls: [process.env.RABBITMQ_URL || 'amqp://guest:guest@rabbitmq:5672'],
                queue: queueName,
                queueOptions: {
-                       durable: true,
-               },
-               exchange: RmqExchanges.reports,
-               exchangeType: 'direct',
-               exchangeOptions: {
                        durable: true,
                },
        };

--- a/apps/backend/src/shared/rmq/rmq.constants.ts
+++ b/apps/backend/src/shared/rmq/rmq.constants.ts
@@ -1,1 +1,0 @@
-export const InjectQueueClient = 'RABBITMQ_CLIENT';

--- a/apps/backend/src/shared/rmq/rmq.module.ts
+++ b/apps/backend/src/shared/rmq/rmq.module.ts
@@ -1,19 +1,8 @@
 import {Module} from '@nestjs/common';
-import {ClientsModule, Transport} from '@nestjs/microservices';
 import {RmqPublisherService} from './rmq-publisher.service';
-import {createRmqClientOptions, RmqQueues} from './rmq.config';
 
 @Module({
-	imports: [
-		ClientsModule.register([
-			{
-				name: RmqQueues.portfolio.name,
-				transport: Transport.RMQ,
-				options: createRmqClientOptions(RmqQueues.portfolio.queue),
-			},
-		]),
-	],
-	providers: [RmqPublisherService],
-	exports: [RmqPublisherService],
+       providers: [RmqPublisherService],
+       exports: [RmqPublisherService],
 })
 export class RmqModule {}

--- a/apps/frontend/src/components/portfolio/portfolioReport/ShowPortfolioReportButton.tsx
+++ b/apps/frontend/src/components/portfolio/portfolioReport/ShowPortfolioReportButton.tsx
@@ -32,11 +32,13 @@ const ShowPortfolioReportButton: React.FC<CreatePortfolioReportButtonProps> = ({
 				</Button>
 			)}
 
-			<ShowPortfolioReportDrawer
-				portfolioId={portfolioId}
-				open={open}
-				onOpenChange={(open) => setOpen(open)}
-			/>
+			{open && (
+				<ShowPortfolioReportDrawer
+					portfolioId={portfolioId}
+					open
+					onOpenChange={(open) => setOpen(open)}
+				/>
+			)}
 		</>
 	);
 };


### PR DESCRIPTION
## Summary
- add direct exchange configuration for RabbitMQ
- publish backend events via amqp-connection-manager
- update Python publisher to use the same exchange

## Testing
- `npm run --workspace apps/backend build` *(fails: jest/tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f57b7db748322afe0acb247381ae5